### PR TITLE
provides old libkitten identifier in control file

### DIFF
--- a/control
+++ b/control
@@ -2,7 +2,7 @@ Package: dev.traurige.libkitten
 Name: libKitten
 Depends: firmware (>= 12.0)
 Conflicts: love.litten.libkitten
-Provides: love.litten.libkitten
+Provides: love.litten.libkitten (=1.3.3)
 Version: 1.3.3
 Architecture: iphoneos-arm
 Description: Collection of image and color calculations

--- a/control
+++ b/control
@@ -2,6 +2,7 @@ Package: dev.traurige.libkitten
 Name: libKitten
 Depends: firmware (>= 12.0)
 Conflicts: love.litten.libkitten
+Provides: love.litten.libkitten
 Version: 1.3.3
 Architecture: iphoneos-arm
 Description: Collection of image and color calculations


### PR DESCRIPTION
tweaks using the old identifier don't need an update if you add provides to the control file